### PR TITLE
docker-compose fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./data:/app/data
     ports:
       - "5005:5005"
-    command: python -m rasa_core.run   --enable_api -c rest  data/servicing-bot-en/models/dialogue -u data/servicing-bot-en/models/servicing-bot-en/model-en --endpoints endpoints.yml --credentials credentials.yml --debug
+    command: python -m rasa_core.run   --enable_api -c rest  -d data/servicing-bot-en/models/dialogue -u data/servicing-bot-en/models/servicing-bot-en/model-en --endpoints endpoints.yml --credentials credentials.yml --debug
   action:  
     image: action_server
     build:


### PR DESCRIPTION
Docker compose fails to start `rasa_en` container due to missing -d flag:
* Adds missing -d flag thats stops docker-container from starting up properly